### PR TITLE
Add rehydrate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This project is an ETL to load iot-poc files into arangodb.
 Notes:
 
 - The iot-poc files are processed out-of-order asynchronously.
-- The arango-etl binary target currently exposes the following two commands:
+- The arango-etl binary target currently exposes the following commands:
     - `history`: this takes a `--before` and `--after` utc timestamp.
+    - `rehydrate`: this takes only a `--date` utc date.
     - `current`: this takes only an `--after` utc timestamp.
 
 ## Contents
@@ -33,12 +34,17 @@ $ cargo build --release
 
 - In this mode the S3 bucket is checked for iot-poc files between after and before
 (both inclusive) timestamps.
-- Currently, we cannot use AWS profiles so it's recommended to do only a couple
-  hours worth of data ingestion.
-
 
 ```bash
 $ ./target/release/arango-etl -c settings.toml history --after "2023-05-01T00:00:00" --before "2023-05-01T02:00:00"
+```
+
+### `rehydrate` mode:
+
+- In this mode the S3 bucket is checked for iot-poc files for a given date.
+
+```bash
+$ ./target/release/arango-etl -c settings.toml rehydrate --date "2023-05-01"
 ```
 
 ### `current` mode:
@@ -48,15 +54,9 @@ $ ./target/release/arango-etl -c settings.toml history --after "2023-05-01T00:00
 - This mode starts a server which ticks at a specified interval (refer
   settings.toml.template), processes files matching timestamps greater than or
   equal to the after timestamp.
-- After each tick the after timestamp internally gets updated to continue
-  processing newer files.
+- After each tick the after timestamp internally gets updated to the last
+  processed file's timestamp and continues waiting for newer files to appear.
 
 ```bash
 $ ./target/release/arango-etl -c settings.toml current --after "2023-05-01T00:00:00"
 ```
-
-## Caveats
-
-- Currently, we cannot use AWS profiles so it's recommended to do only a
-couple hours  worth of data ingestion using history mode.
-- The `current` mode needs more thorough testing and might be a bit flaky.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,2 +1,3 @@
 pub mod current;
 pub mod history;
+pub mod rehydrate;

--- a/src/cli/rehydrate.rs
+++ b/src/cli/rehydrate.rs
@@ -1,0 +1,40 @@
+use crate::{handler::ArangodbHandler, settings::Settings};
+use anyhow::{Context, Result};
+use chrono::{Days, NaiveDate, TimeZone, Utc};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[derive(Debug, clap::Args)]
+pub struct Cmd {
+    /// Required date to rehydrate
+    #[clap(long)]
+    date: NaiveDate,
+}
+
+impl Cmd {
+    pub async fn run(&self, settings: &Settings) -> Result<()> {
+        tracing_subscriber::registry()
+            .with(tracing_subscriber::EnvFilter::new(&settings.log))
+            .with(tracing_subscriber::fmt::layer())
+            .init();
+
+        let after = self
+            .date
+            .and_hms_opt(00, 00, 00)
+            .context("unable to get after date")?;
+        let before = self
+            .date
+            .checked_add_days(Days::new(1))
+            .context("unable to add 1 day")?
+            .and_hms_opt(00, 00, 00)
+            .context("unable to get before date")?;
+        let after_utc = Utc.from_utc_datetime(&after);
+        let before_utc = Utc.from_utc_datetime(&before);
+
+        tracing::info!("after_utc: {:?}", after_utc);
+        tracing::info!("before_utc: {:?}", before_utc);
+
+        let handler = ArangodbHandler::new(settings).await?;
+        handler.process(after_utc, Some(before_utc)).await?;
+        Ok(())
+    }
+}

--- a/src/document/iot_poc_file.rs
+++ b/src/document/iot_poc_file.rs
@@ -1,0 +1,24 @@
+use chrono::{DateTime, Utc};
+use file_store::FileInfo;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct IotPocFile {
+    pub _key: String,
+    pub timestamp: DateTime<Utc>,
+    pub unix_ts: i64,
+    pub size: usize,
+    pub done: bool,
+}
+
+impl From<&FileInfo> for IotPocFile {
+    fn from(fi: &FileInfo) -> Self {
+        Self {
+            _key: fi.key.clone(),
+            size: fi.size,
+            timestamp: fi.timestamp,
+            unix_ts: fi.timestamp.timestamp_millis(),
+            done: false,
+        }
+    }
+}

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -1,6 +1,7 @@
 pub mod beacon;
 pub mod edge;
 pub mod hotspot;
+pub mod iot_poc_file;
 pub mod witness;
 
 pub use beacon::Beacon;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use arango_etl::{
-    cli::{current, history},
+    cli::{current, history, rehydrate},
     settings::Settings,
 };
 use clap::Parser;
@@ -10,6 +10,8 @@ use std::path;
 pub enum Cmd {
     /// Run in historical data gathering mode
     History(history::Cmd),
+    /// Run in reyhdrate mode
+    Rehydrate(rehydrate::Cmd),
     /// Run in current mode by starting a server
     Current(current::Server),
 }
@@ -18,6 +20,7 @@ impl Cmd {
     pub async fn run(self, settings: Settings) -> Result<()> {
         match self {
             Self::History(cmd) => cmd.run(&settings).await,
+            Self::Rehydrate(cmd) => cmd.run(&settings).await,
             Self::Current(cmd) => cmd.run(&settings).await,
         }
     }


### PR DESCRIPTION
Summary
----
This adds a rehydrate command which takes in a single `date` arg and populates the DB for all the poc files for that date.

Example:

```shell
./target/release/arango-etl -c settings.toml rehydrate --date "2023-06-03"
```