### PR TITLE
Add hotspot name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "angry-purple-tiger"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7556be6f2b0d82376c1ece1fda4dffd728816ac53bee2c285f3f74269ddc4a97"
+dependencies = [
+ "anyhow",
+ "clap 4.3.1",
+ "md5",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +134,7 @@ dependencies = [
 name = "arango-etl"
 version = "0.1.0"
 dependencies = [
+ "angry-purple-tiger",
  "anyhow",
  "arangors",
  "base64 0.21.2",
@@ -2302,6 +2314,12 @@ checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ deadpool-redis = { version = "0", features = [ "rt_tokio_1" ] }
 rust_decimal = "1"
 h3o = { version = "0.3.2", features = [ "geo" ] }
 geojson = "0.24.1"
+angry-purple-tiger = "1.0.0"

--- a/src/document/hotspot.rs
+++ b/src/document/hotspot.rs
@@ -1,4 +1,6 @@
 use crate::document::{Beacon, Witness};
+use angry_purple_tiger::AnimalName;
+use anyhow::{Error, Result};
 use geojson::Geometry;
 use helium_crypto::PublicKeyBinary;
 use serde::{Deserialize, Serialize};
@@ -6,35 +8,49 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Hotspot {
     _key: PublicKeyBinary,
-    pub_key: PublicKeyBinary,
     location: Option<u64>,
     latitude: Option<f64>,
     longitude: Option<f64>,
     geo: Option<Geometry>,
+    name: String,
 }
 
-impl From<&Beacon> for Hotspot {
-    fn from(beacon: &Beacon) -> Self {
-        Self {
+impl TryFrom<&Beacon> for Hotspot {
+    type Error = Error;
+
+    fn try_from(beacon: &Beacon) -> Result<Self> {
+        let name = beacon
+            .pub_key
+            .to_string()
+            .parse::<AnimalName>()?
+            .to_string();
+        Ok(Self {
             _key: beacon.pub_key.clone(),
-            pub_key: beacon.pub_key.clone(),
             location: beacon.location,
             latitude: beacon.latitude,
             longitude: beacon.longitude,
             geo: beacon.geo.clone(),
-        }
+            name,
+        })
     }
 }
 
-impl From<&Witness> for Hotspot {
-    fn from(witness: &Witness) -> Self {
-        Self {
+impl TryFrom<&Witness> for Hotspot {
+    type Error = Error;
+
+    fn try_from(witness: &Witness) -> Result<Self> {
+        let name = witness
+            .pub_key
+            .to_string()
+            .parse::<AnimalName>()?
+            .to_string();
+        Ok(Self {
             _key: witness.pub_key.clone(),
-            pub_key: witness.pub_key.clone(),
             location: witness.location,
             latitude: witness.latitude,
             longitude: witness.longitude,
             geo: witness.geo.clone(),
-        }
+            name,
+        })
     }
 }

--- a/src/handler/arangodb.rs
+++ b/src/handler/arangodb.rs
@@ -203,7 +203,7 @@ impl DB {
 
         // insert beacon hotspot
         let poc_id = beacon.poc_id.clone();
-        let beacon_hotspot = Hotspot::from(&beacon);
+        let beacon_hotspot = Hotspot::try_from(&beacon)?;
         self.populate_hotspot(beacon_hotspot).await?;
 
         for witness in beacon.witnesses.iter() {


### PR DESCRIPTION
- This adds hotspot.name field to documents in the hotspot collection
- Also removes hotspot.pub_key, it's already used as the _key for hotspot documents