### PR TITLE
Add poc_ids to hotspot document

### DIFF
--- a/src/document/hotspot.rs
+++ b/src/document/hotspot.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Hotspot {
-    _key: PublicKeyBinary,
+    pub _key: PublicKeyBinary,
+    pub poc_ids: Vec<String>,
     location: Option<u64>,
     latitude: Option<f64>,
     longitude: Option<f64>,
@@ -26,6 +27,7 @@ impl TryFrom<&Beacon> for Hotspot {
             longitude: beacon.longitude,
             geo: beacon.geo.clone(),
             name,
+            poc_ids: vec![beacon.poc_id.clone()],
         })
     }
 }
@@ -42,6 +44,7 @@ impl TryFrom<&Witness> for Hotspot {
             longitude: witness.longitude,
             geo: witness.geo.clone(),
             name,
+            poc_ids: vec![],
         })
     }
 }


### PR DESCRIPTION
This adds poc_ids to hotspot documents. This makes it easier to know the poc_ids a particular hotspot initiated as the beaconer.

So you can do queries like:

```sql
FOR h IN hotspots
FILTER LENGTH(h.poc_ids) > 1
RETURN { count: LENGTH(doc.poc_ids) }
```

This also adds some extra functions to check existence of files, beacons and hotspot before they get inserted in the database; this actually helps the db performance a bit since there aren't any conflicting inserts after this patch.